### PR TITLE
Rebuild/0.2.0.b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - dash >=1.0.0
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,9 @@ about:
   home: "http://github.com/plotly/dash-bio"
   license: "MIT"
   license_family: "MIT"
-  license_file: ""
+  license_file: "LICENSE"
   summary: "dash_bio"
+  description: |
+    Dash Bio is a suite of bioinformatics components built to work with Dash.
   doc_url: "https://dash.plot.ly/dash-bio"
-  dev_url: "http://github.com/plotly/dash-bio"
+  dev_url: "https://github.com/plotly/dash-bio"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ about:
   home: "http://github.com/plotly/dash-bio"
   license: "MIT"
   license_family: "MIT"
-  license_file: "LICENSE"
+  license_url: "https://github.com/plotly/dash-bio/blob/v0.2.0/LICENSE"
   summary: "dash_bio"
   description: |
     Dash Bio is a suite of bioinformatics components built to work with Dash.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   imports:
     - dash_bio
     - dash_bio.component_factory
-  commdands:
+  commands:
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,13 @@ requirements:
     - scipy
 
 test:
+  requires:
+    - pip
   imports:
     - dash_bio
     - dash_bio.component_factory
+  commdands:
+    - pip check
 
 about:
   home: "http://github.com/plotly/dash-bio"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
+    - setuptools
     - dash >=1.0.0
     - pandas
     - plotly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ test:
     - pip check
 
 about:
-  home: "http://github.com/plotly/dash-bio"
+  home: "https://github.com/plotly/dash-bio"
   license: "MIT"
   license_family: "MIT"
   license_url: "https://github.com/plotly/dash-bio/blob/v0.2.0/LICENSE"
   summary: "dash_bio"
   description: |
     Dash Bio is a suite of bioinformatics components built to work with Dash.
-  doc_url: "https://dash.plot.ly/dash-bio"
+  doc_url: "https://dash.plotly.com/dash-bio"
   dev_url: "https://github.com/plotly/dash-bio"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,7 @@ about:
     Dash Bio is a suite of bioinformatics components built to work with Dash.
   doc_url: "https://dash.plotly.com/dash-bio"
   dev_url: "https://github.com/plotly/dash-bio"
+
+extra:
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: "526d6804646891cbed75b5ecc8001ed73cff0f2f3874c1b42b8b34007c8af63e"
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:


### PR DESCRIPTION
Fixes `No module named 'pkg_resources'` on windows for Python 3.11